### PR TITLE
Prefer wrapProgram and parameterize uberjarName

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,9 @@ Building locally
 
 `nix-build -I project=/path/to/lein/project`
 
+As needed, pass `--argstr uberjarName "project.jar"` to replace the default,
+`*-standalone.jar`.
+
 Building on hydra
 ------------------
 

--- a/default.nix
+++ b/default.nix
@@ -4,6 +4,7 @@ let pkgs = import <nixpkgs> {}; in
 , jdk ? pkgs.jdk
 , stdenv ? pkgs.stdenv
 , project ? <project>
+, uberjarName ? "*standalone.jar"
 }:
 let
   inherit (buildMaven (project + "/project-info.json")) repo build info;
@@ -29,6 +30,6 @@ in stdenv.mkDerivation {
   buildPhase = "lein uberjar";
 
   installPhase = ''
-    find . -name '*standalone.jar' -exec mv '{}' $out \;
+    find . -name '${uberjarName}' -exec mv '{}' $out \;
   '';
 }

--- a/default.nix
+++ b/default.nix
@@ -14,16 +14,15 @@ in stdenv.mkDerivation {
 
   buildInputs = [ leiningen ];
 
+  nativeBuildInputs = [ pkgs.makeWrapper ];
+
   LEIN_OFFLINE = 1;
 
   configurePhase = ''
     mkdir -p home/.m2
     ln -s ${repo} home/.m2/repository
-    # This is so hacky!
-    cat > java <<EOF
-    exec ${jdk}/bin/java -Duser.home=$PWD/home "\$@"
-    EOF
-    chmod +x java
+    ln -s ${jdk}/bin/java java
+    wrapProgram java --add-flags -Duser.home=$PWD/home
     export LEIN_JAVA_CMD=$PWD/java
   '';
 


### PR DESCRIPTION
TODO: it would be great to parse `project.clj` for `:uberjar-name` instead/also.